### PR TITLE
fix (network): Add the port number to the `control_path`

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -39,6 +39,4 @@ ssh_args                      = -4 -F ./ssh.cfg
 # Control path for persistent ssh connection
 # https://bit.ly/ansible-control_path
 # shortcuts: %h = hostname, %r = remote user
-control_path                  = %(directory)s/%%h-%%r
-
-
+control_path                  = %(directory)s/%%r@%%h:%%p


### PR DESCRIPTION
To avoid interference with other hosts during provisioning or Ansible testing.