### PR TITLE
chore: Skip security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,15 +25,15 @@ updates:
         labels:
           - "python"
           - "dependencies"
-      minor-and-patch:
-        applies-to: "security-updates"
-        update-types:
-          - "patch"
-          - "minor"
-        labels:
-          - "python"
-          - "dependencies"
-          - "security"
+      # minor-and-patch:
+      #   applies-to: "security-updates"
+      #   update-types:
+      #     - "patch"
+      #     - "minor"
+      #   labels:
+      #     - "python"
+      #     - "dependencies"
+      #     - "security"
     commit-message:
       prefix: "pip: "
       include: "scope"


### PR DESCRIPTION
Because:

> [!note] If a grouped pull request for Dependabot version updates contains a vulnerable package, Dependabot security updates will still attempt to create a separate pull request to update the vulnerable package to a secure version. Creating a separate pull request for security updates ensures you have visibility into package vulnerabilities.
> - [about groups](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups)